### PR TITLE
Download boilerplate templates from the GitHub repository directly

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,6 +6,7 @@ import { templateMissingOptionPrompt } from './prompts/template';
 import { downloadTemplateKit } from './main';
 import { Ioptions } from './interfaces';
 import { prettify } from '../lib/js/helpers/prettify';
+import { versioningRelease } from './prompts/release-version';
 
 let parseArgumentsIntoOptions = (rawArgs: string[]) => {
 
@@ -53,6 +54,7 @@ let parseArgumentsIntoOptions = (rawArgs: string[]) => {
       skipGit: args['--skip-git'],
       folderName: args._[0],
       template: args._[1],
+      releaseVersion: args._[2],
       runInstall: args['--install'] || true,
       skipInstall: args['--skip-install'] || false,
       help: args['--help'] || false,
@@ -76,7 +78,9 @@ let otherOptions = async (options: Ioptions) => {
 
   options = await templateMissingOptionPrompt(updatedOptions, folderNameAnswers, defaultFolderName);
 
-  // consoleLog(options);
+  options = await versioningRelease(options)
+
+  // console.log(options);
 
   try {
     await downloadTemplateKit(options);

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -20,6 +20,7 @@ export interface Ioptions {
   skipInstall: boolean;
   help: string | boolean;
   version: string | boolean;
+  releaseVersion: string;
 }
 
 export interface IFoldernameAnswers {

--- a/src/prompts/release-version.ts
+++ b/src/prompts/release-version.ts
@@ -1,0 +1,47 @@
+import { execSync } from "child_process";
+import inquirer from 'inquirer';
+import { Ioptions, TemplateQuestions } from "../interfaces";
+import { prettify } from "../../lib/js/helpers/prettify";
+
+export const versioningRelease = async (options: Ioptions) => {
+    const releaseQuestions: TemplateQuestions[]  = [];
+     const repoUrl = 'https://github.com/collabo-community/backend-api-boilerplates.git'
+
+     const result = execSync(`git ls-remote --heads ${repoUrl}`).toString();
+
+    const tags = result.trim().split('\n');
+
+     // Filter out branches that don't contain '@release/'
+     const releaseTags = tags.filter(tag => tag.includes('@release/')).map(tag => tag.split('/').pop());
+
+     let versioningAnswers: { version: string } 
+
+     const isVersionExist = releaseTags.some(vers => {
+        return vers === options.releaseVersion;
+      });
+
+      const notAmongVersionCollection = isVersionExist === false;
+
+      if (notAmongVersionCollection && options.releaseVersion !== undefined && !options.skipPrompts) prettify.log.color.none(`${prettify.text.error(`${options.releaseVersion}`)} does not exist in create-collabo-app backend API template version`);
+
+     if (!options.releaseVersion || notAmongVersionCollection) {
+        releaseQuestions.push({
+          type: 'list',
+          name: 'version',
+          message: 'Please choose which create-collabo-app API boilerplate version to use :',
+          choices: releaseTags as string[],
+          default: releaseTags[releaseTags.length - 1] || ''
+        });
+      }
+
+      versioningAnswers = await inquirer.prompt(releaseQuestions);
+
+    //   console.log(releaseTags)
+
+    options = {
+        ...options,
+        releaseVersion: options.releaseVersion || versioningAnswers.version
+    }
+
+    return options
+}


### PR DESCRIPTION
**This pull request makes the following changes:**
* https://discord.com/channels/1148391778492354741/1253584233155395657/1257637631022469173 

**General checklist**
- [ ] File or folder now contains changes as specified in the issue i worked on
- [x] I have linked the issue I worked on to this pull request submitted by me

**Testing checklist**

- The `main.ts` file contains functions that clones boilerplates templates and deletes it after.
- The `versioningRelease file checks for available version of boilerplate templates`

PS: this version doesn't completely work yet, You will encounter the following error

```
ERROR Template name or directory path is (probably) incorrect

It looks like the create-collabo-app does not work yet for your computer's operating system. Let us know the issue with the CLI on your computer's operating system by reporting it here:
https://github.com/collabo-community/user-issue-report/issues

Alternatively, you can download and access the API boilerplate templates from the template's github repo:
https://github.com/collabo-community/backend-api-boilerplates

```
This is because the template you chose does not exist in the boilerplates template that was cloned.

Another Error you might encounter is: 
`Failed to clone repository: fatal: destination path 'templates' already exists and is not an empty directory.`
This also happens because we have an existing folder named templates and we are trying to clone the boilerplates templates into it